### PR TITLE
Correction of the getBlockByHash function - QueryQSCC Handler: hashBytes, err := hex.DecodeString(hash), passed as a parameter to the chaincode.QueryGateway function, assigned to result.

### DIFF
--- a/ccapi/docs/swagger.yaml
+++ b/ccapi/docs/swagger.yaml
@@ -947,6 +947,42 @@ paths:
         - application/json
       produces:
         - application/json
+  /{channelName}/qscc/getBlockByHash:
+    get:
+      summary: Get block by hash
+      description: Retrieves a block by its hash from the specified channel.
+      tags:
+        - Blockchain
+      security:
+        - basicAuth: []
+      parameters:
+        - name: channelName
+          in: path
+          required: true
+          schema:
+            type: string
+            example: mainchannel
+          description: Name of the channel.
+        - name: hash
+          in: query
+          required: true
+          schema:
+            type: string
+            example: dbd2b14fb3d61b7aeac3add76f99cd9b47850c7c95ca5e489696a6b543fc6b2d
+          description: The hash of the block to be retrieved.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Bad request
+        "404":
+          description: Block not found
+        "500":
+          description: Internal server error
   /{channelName}/qscc/getChainInfo:
     get:
       summary: Get chain info

--- a/ccapi/handlers/qscc.go
+++ b/ccapi/handlers/qscc.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
-
+	
 	"github.com/gin-gonic/gin"
 	"github.com/hyperledger-labs/ccapi/chaincode"
 	"github.com/hyperledger-labs/ccapi/common"
@@ -24,8 +24,8 @@ func QueryQSCC(c *gin.Context) {
 	switch txname {
 	case "getBlockByNumber":
 		getBlockByNumber(c, channelName)
-	// case "getBlockByHash":
-	// 	getBlockByHash(c, channelName)
+	case "getBlockByHash":
+	getBlockByHash(c, channelName)
 	case "getTransactionByID":
 		getTransactionByID(c, channelName)
 	case "getChainInfo":
@@ -139,7 +139,15 @@ func getBlockByHash(c *gin.Context, channelName string) {
 		return
 	}
 
-	result, err := chaincode.QueryGateway(channelName, "qscc", "GetBlockByHash", user, []string{channelName, hash})
+	hashBytes, err := hex.DecodeString(hash)
+
+	if err != nil {
+		common.Abort(c, http.StatusBadRequest, fmt.Errorf("invalid hash format: %s", hash))
+		return
+	}
+
+	result, err := chaincode.QueryGateway(channelName, "qscc", "GetBlockByHash", user, []string{channelName, string(hashBytes)})
+	
 	if err != nil {
 		err, status := common.ParseError(err)
 		common.Abort(c, status, err)


### PR DESCRIPTION
Signed-off-by: Matheus Lázaro <matheus.lazaro@discente.ufg.br>